### PR TITLE
typo in method name (but still worked cause typo was in both places)

### DIFF
--- a/app/controllers/snorlax/base.rb
+++ b/app/controllers/snorlax/base.rb
@@ -18,7 +18,7 @@ module Snorlax
         end
 
         def create
-          instantiate_resouce
+          instantiate_resource
           create_action
           respond_with_resource
         end
@@ -65,7 +65,7 @@ module Snorlax
           instance_variable_set :"@#{resource_name.pluralize}", value
         end
 
-        def instantiate_resouce
+        def instantiate_resource
           self.resource = resource_class.new(resource_params)
         end
 


### PR DESCRIPTION
I found this one because I was trying to call `instantiate_resouRce` from within an function override. 

Caution about merging this one, because I haven't looked, but Loomio itself may make reference to this misnamed function at some places in the code.