### PR TITLE
remove dependency on cancan/cancancan

### DIFF
--- a/app/controllers/snorlax/base.rb
+++ b/app/controllers/snorlax/base.rb
@@ -3,7 +3,10 @@ module Snorlax
 
     def self.snorlax_used_rest!(controller)
       controller.class_eval do
-        rescue_from(CanCan::AccessDenied)                    { |e| respond_with_standard_error e, 403 }
+        if defined? CanCan::AccessDenied
+          rescue_from(CanCan::AccessDenied)                    { |e| respond_with_standard_error e, 403 }
+        end
+
         rescue_from(ActionController::UnpermittedParameters) { |e| respond_with_standard_error e, 400 }
         rescue_from(ActionController::ParameterMissing)      { |e| respond_with_standard_error e, 400 }
         rescue_from(ActiveRecord::RecordNotFound)            { |e| respond_with_standard_error e, 404 }


### PR DESCRIPTION
We've recently added snorlax to github.com/metamaps/metamaps_gen002. We struggled a bit with the dependency on cancancan. We had to explicitly require 'cancancan' at the top of our api controllers.

I believe this commit will fix that. You could even go a step further and remove cancancan from your Gemfile/gemspec if it really does work, but I'm not confident enough in my knowledge of snorlax to propose that. I could make those commits.

Also, we recently moved to pundit, and added this line to our base api controller:

    rescue_from(Pundit::NotAuthorizedError) { |e| respond_with_standard_error e, 403 }

I could add this line to the PR if y'all are interested.

I've made the extra changes on this branch: https://github.com/loomio/snorlax/compare/master...metamaps:any-permissions-lib